### PR TITLE
Refactor parser, add asserts

### DIFF
--- a/src/main/java/botato/Botato.java
+++ b/src/main/java/botato/Botato.java
@@ -31,6 +31,8 @@ public class Botato {
             return c.execute(tasks, ui); // Execute the parsed command, affecting the task list and UI.
         } catch (BotatoException e) {
             return e.getMessage(); // Show error message if there's an issue with the command.
+        } catch (Exception e) {
+            return "An error occurred: " + e.getMessage();
         }
     }
     /**

--- a/src/main/java/botato/Parser.java
+++ b/src/main/java/botato/Parser.java
@@ -13,6 +13,8 @@ import botato.command.MarkCommand;
 import botato.command.TodoCommand;
 import botato.command.UnmarkCommand;
 import botato.exception.InvalidCommandException;
+import botato.exception.InvalidTaskNumberException;
+import botato.exception.MissingKeywordException;
 
 /**
  * The parser class takes a user input string and returns a {@link Command} object.
@@ -26,6 +28,7 @@ public class Parser {
      * @return {@link Command} object based on input.
      */
     public static Command parse(String cmd) {
+        assert cmd != null : "Input cannot be null";
         if (cmd.equals("bye")) {
             // Save data and exit chatbot
             return new ExitCommand();
@@ -34,10 +37,12 @@ public class Parser {
             return new ListCommand();
         } else if (cmd.matches("^mark \\d+$")) {
             // Mark specific task as completed
-            return new MarkCommand(cmd);
+            int taskNumber = validateAndGetTaskNumber(cmd);
+            return new MarkCommand(taskNumber);
         } else if (cmd.matches("^unmark \\d+$")) {
             // Mark specified task as not done
-            return new UnmarkCommand(cmd);
+            int taskNumber = validateAndGetTaskNumber(cmd);
+            return new UnmarkCommand(taskNumber);
         } else if (cmd.matches("^todo\\s+.+$")) {
             // Add a Task of type Todo to tasks
             return new TodoCommand(cmd);
@@ -49,15 +54,34 @@ public class Parser {
             return new EventCommand(cmd);
         } else if (cmd.matches("^delete \\d+$")) {
             // Delete a specified task based on task number given
-            return new DeleteCommand(cmd);
+            int taskNumber = validateAndGetTaskNumber(cmd);
+            return new DeleteCommand(taskNumber);
         } else if (cmd.equals("help")) {
             // Opens help interface
             return new HelpCommand();
         } else if (cmd.matches("^find\\s+.+")) {
-            return new FindCommand(cmd);
+            String keyword = validateAndGetKeyword(cmd);
+            return new FindCommand(keyword);
         } else {
             // Handle invalid commands
             throw new InvalidCommandException();
         }
     }
+
+    private static int validateAndGetTaskNumber(String cmd) {
+        int taskNumber = Integer.parseInt(cmd.split(" ")[1]);
+        if (taskNumber <=0 || taskNumber > TaskList.size()) {
+            throw new InvalidTaskNumberException(TaskList.size());
+        }
+        return taskNumber;
+    }
+
+    private static String validateAndGetKeyword(String cmd) {
+        String keyword = cmd.substring(cmd.indexOf(" "));
+        if (keyword.isBlank()) {
+            throw new MissingKeywordException();
+        }
+        return keyword;
+    }
+
 }

--- a/src/main/java/botato/TaskList.java
+++ b/src/main/java/botato/TaskList.java
@@ -12,7 +12,7 @@ import botato.task.Task;
  * tasks as complete or incomplete and provides a method to display all tasks in a formatted manner.
  */
 public class TaskList {
-    private static ArrayList<Task> taskArrayList;
+    private static ArrayList<Task> taskArrayList = new ArrayList<>();
     public TaskList() {
         taskArrayList = Storage.load();
     }
@@ -22,7 +22,7 @@ public class TaskList {
      *
      * @return number of elements in taskArrayList.
      */
-    public int size() {
+    public static int size() {
         return taskArrayList.size();
     }
 

--- a/src/main/java/botato/command/DeleteCommand.java
+++ b/src/main/java/botato/command/DeleteCommand.java
@@ -11,18 +11,15 @@ import botato.task.Task;
  * input string.
  */
 public class DeleteCommand extends Command {
-    private final String cmd;
-    public DeleteCommand(String cmd) {
-        this.cmd = cmd;
+    private final int taskNumber;
+    public DeleteCommand(int taskNumber) {
+        this.taskNumber = taskNumber;
     }
     @Override
     public String execute(TaskList tasks, Ui ui) {
-        String taskStr = cmd.substring(6).strip(); // Extract desired task number
-        int taskNum = Integer.parseInt(taskStr);
-        if (taskNum <= 0 || taskNum > tasks.size()) {
-            throw new InvalidTaskNumberException(tasks.size());
-        }
-        Task removedTask = tasks.deleteTask(taskNum);
+        assert taskNumber > 0 : "Task number must be greater than 0.";
+        assert taskNumber <= TaskList.size() : "Task number must be less than or equal to TaskList.size()";
+        Task removedTask = tasks.deleteTask(taskNumber);
         System.out.println("Task has been successfully removed:\n" + removedTask);
         return "Task has been successfully removed:\n" + removedTask;
     }

--- a/src/main/java/botato/command/FindCommand.java
+++ b/src/main/java/botato/command/FindCommand.java
@@ -10,17 +10,13 @@ import botato.exception.MissingKeywordException;
  * in the given task list. Then, the found tasks (if any) are printed.
  */
 public class FindCommand extends Command {
-    private final String cmd;
+    private final String keyword;
 
-    public FindCommand(String cmd) {
-        this.cmd = cmd;
+    public FindCommand(String keyword) {
+        this.keyword = keyword;
     }
     @Override
     public String execute(TaskList tasks, Ui ui) {
-        String keyword = cmd.substring(4).strip();
-        if (keyword.isBlank()) {
-            throw new MissingKeywordException();
-        }
         return tasks.find(keyword);
     }
 }

--- a/src/main/java/botato/command/MarkCommand.java
+++ b/src/main/java/botato/command/MarkCommand.java
@@ -9,18 +9,16 @@ import botato.exception.InvalidTaskNumberException;
  * When executed, it marks a task as complete based on the user's input string.
  */
 public class MarkCommand extends Command {
-    private final String cmd;
+    private final int taskNumber;
 
-    public MarkCommand(String cmd) {
-        this.cmd = cmd;
+    public MarkCommand(int taskNumber) {
+        this.taskNumber = taskNumber;
     }
 
     @Override
     public String execute(TaskList tasks, Ui ui) {
-        int taskNum = Integer.parseInt(cmd.substring(4).strip());
-        if (taskNum <= 0 || taskNum > tasks.size()) {
-            throw new InvalidTaskNumberException(tasks.size());
-        }
-        return tasks.setTaskStatus(taskNum, true);
+        assert taskNumber > 0 : "Task number must be greater than 0.";
+        assert taskNumber <= TaskList.size() : "Task number must be less than or equal to TaskList.size()";
+        return tasks.setTaskStatus(taskNumber, true);
     }
 }

--- a/src/main/java/botato/command/UnmarkCommand.java
+++ b/src/main/java/botato/command/UnmarkCommand.java
@@ -9,16 +9,14 @@ import botato.exception.InvalidTaskNumberException;
  * When executed, it marks a command as incomplete based on the index from the user input string.
  */
 public class UnmarkCommand extends Command {
-    private final String cmd;
-    public UnmarkCommand(String cmd) {
-        this.cmd = cmd;
+    private int taskNumber;
+    public UnmarkCommand(int taskNumber) {
+        this.taskNumber = taskNumber;
     }
     @Override
     public String execute(TaskList tasks, Ui ui) {
-        int taskNum = Integer.parseInt(cmd.substring(6).strip());
-        if (taskNum <= 0 || taskNum > tasks.size()) {
-            throw new InvalidTaskNumberException(tasks.size());
-        }
-        return tasks.setTaskStatus(taskNum, false);
+        assert taskNumber > 0 : "Task number must be greater than 0.";
+        assert taskNumber <= TaskList.size() : "Task number must be less than or equal to TaskList.size()";
+        return tasks.setTaskStatus(taskNumber, false);
     }
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -5,11 +5,18 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Font?>
 
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="botato.MainWindow">
     <children>
-        <TextField fx:id="userInput" layoutY="558.0" onAction="#handleUserInput" prefHeight="41.0" prefWidth="324.0" AnchorPane.bottomAnchor="1.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="76.0" />
-        <Button fx:id="sendButton" layoutX="324.0" layoutY="558.0" mnemonicParsing="false" onAction="#handleUserInput" prefHeight="41.0" prefWidth="76.0" text="Send" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="0.0" />
+        <TextField fx:id="userInput" layoutY="558.0" onAction="#handleUserInput" prefHeight="41.0" prefWidth="324.0" AnchorPane.bottomAnchor="1.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="76.0">
+         <font>
+            <Font size="10.0" />
+         </font></TextField>
+        <Button fx:id="sendButton" layoutX="324.0" layoutY="558.0" mnemonicParsing="false" onAction="#handleUserInput" prefHeight="41.0" prefWidth="76.0" text="Send" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="0.0">
+         <font>
+            <Font size="10.0" />
+         </font></Button>
         <ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" hvalue="1.0" prefHeight="557.0" prefWidth="400.0" vvalue="1.0" AnchorPane.bottomAnchor="43.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
             <content>
                 <VBox fx:id="dialogContainer" prefHeight="552.0" prefWidth="388.0" />


### PR DESCRIPTION
Validating task numbers is handled in the commands that use them.

This causes unnecessary code duplication and reduces code clarity.

Let's validate task numbers in the parser instead.

This makes behaviour clearer and reduces code duplication.

Furthermore, assertions were added to commands using task numbers to ensure task numbers are valid and prevent null pointer errors.